### PR TITLE
fix: Change useFom to useForm at homepage subtitle

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -10,7 +10,7 @@ export default {
   twitter: "https://twitter.com/juciano_barbosa",
   branch: 'master',
   siteName: 'useForm',
-  siteSlogan: 'useFom provides a way to create complex forms easily.',
+  siteSlogan: 'useForm provides a way to create complex forms easily.',
   path: '/',
   titleSuffix: ' – useForm',
   nextLinks: true,


### PR DESCRIPTION
fixing typo on word useForm at docs homepage, changed from useFom to useForm